### PR TITLE
fix(#5): Compile using `rubber`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: required
 dist: trusty
 before_install:
 - sudo apt-get -qq update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended
-  texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended lmodern texlive-science texlive-math-extra pgf
+  texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended lmodern texlive-science texlive-math-extra pgf rubber
 script:
 - mkdir _build
-- pdflatex -interaction=nonstopmode -halt-on-error -output-directory _build template.tex
+- rubber --into _build --pdf template
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
Rubber decides the right amount of compilations needed in order to have all references and TOC instantiated.

Closes #5 